### PR TITLE
Add built-in tool to list, add, and remove MCP servers

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -19,7 +19,8 @@ import { Bug, Moon, Robot, Sun, Trash, PaperPlaneTilt, Stop } from '@phosphor-ic
 // List of tools that require human confirmation
 const toolsRequiringConfirmation: (keyof typeof tools)[] = [
   'getWeatherInformation',
-  'getJurgenInfo'
+  'addMCPServerUrl',
+  'removeMCPServerUrl'
 ]
 
 export default function Chat() {

--- a/src/components/tool-invocation-card/ToolInvocationCard.tsx
+++ b/src/components/tool-invocation-card/ToolInvocationCard.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react'
 import { Robot, CaretDown } from '@phosphor-icons/react'
 import { Button } from '@/components/button/Button'
 import { Card } from '@/components/card/Card'
-import { Tooltip } from '@/components/tooltip/Tooltip'
 import { APPROVAL } from '@/shared'
 
 interface ToolInvocation {
@@ -84,20 +83,18 @@ export function ToolInvocationCard({
               >
                 Reject
               </Button>
-              <Tooltip content={'Accept action'}>
-                <Button
-                  variant="primary"
-                  size="sm"
-                  onClick={() =>
-                    addToolResult({
-                      toolCallId,
-                      result: APPROVAL.YES
-                    })
-                  }
-                >
-                  Approve
-                </Button>
-              </Tooltip>
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={() =>
+                  addToolResult({
+                    toolCallId,
+                    result: APPROVAL.YES
+                  })
+                }
+              >
+                Approve
+              </Button>
             </div>
           )}
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,7 @@ import {
 import { openai } from '@ai-sdk/openai'
 import { processToolCalls } from './utils'
 import { tools, executions } from './tools'
+
 // import { env } from "cloudflare:workers";
 
 const model = openai('gpt-4o-2024-11-20')
@@ -28,7 +29,6 @@ export class Chat extends AIChatAgent<Env> {
    * Handles incoming chat messages and manages the response stream
    * @param onFinish - Callback function executed when streaming completes
    */
-
   async onChatMessage(
     onFinish: StreamTextOnFinishCallback<ToolSet>,
     options?: { abortSignal?: AbortSignal }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -109,10 +109,25 @@ const cancelScheduledTask = tool({
   }
 })
 
-const getJurgenInfo = tool({
-  description: 'Get Jurgen Information',
-  parameters: z.object({ topic: z.string() })
+const addMCPServerUrl = tool({
+  description: 'add a MCP server URL to the MCP client',
+  parameters: z.object({ url: z.string() })
   // Omitting execute function makes this tool require human confirmation
+})
+
+const removeMCPServerUrl = tool({
+  description: 'remove a MCP server URL from the MCP client',
+  parameters: z.object({ url: z.string() })
+  // Omitting execute function makes this tool require human confirmation
+})
+
+const listMCPServers = tool({
+  description: 'List all MCP server URLs known to the MCP client',
+  parameters: z.object({}),
+  execute: async () => {
+    // Dummy implementation: return a static list
+    return ['https://mcp1.example.com', 'https://mcp2.example.com']
+  }
 })
 
 /**
@@ -125,7 +140,9 @@ export const tools = {
   scheduleTask,
   getScheduledTasks,
   cancelScheduledTask,
-  getJurgenInfo
+  addMCPServerUrl,
+  removeMCPServerUrl,
+  listMCPServers
 }
 
 /**
@@ -138,8 +155,12 @@ export const executions = {
     console.log(`Getting weather information for ${city}`)
     return `The weather in ${city} is sunny`
   },
-  getJurgenInfo: async ({ topic }: { topic: string }) => {
-    console.log(`Getting Jurgen Info ${topic}`)
-    return `Jurgen Info ${topic}`
+  addMCPServerUrl: async ({ url }: { url: string }) => {
+    console.log(`Adding MCP server url: ${url}`)
+    return `Added MCP url: ${url}`
+  },
+  removeMCPServerUrl: async ({ url }: { url: string }) => {
+    console.log(`Removing MCP server url: ${url}`)
+    return `Removed MCP url: ${url}`
   }
 }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -116,8 +116,8 @@ const addMCPServerUrl = tool({
 })
 
 const removeMCPServerUrl = tool({
-  description: 'remove a MCP server URL from the MCP client',
-  parameters: z.object({ url: z.string() })
+  description: 'remove a MCP server by id from the MCP client',
+  parameters: z.object({ id: z.string() })
   // Omitting execute function makes this tool require human confirmation
 })
 
@@ -125,8 +125,9 @@ const listMCPServers = tool({
   description: 'List all MCP server URLs known to the MCP client',
   parameters: z.object({}),
   execute: async () => {
-    // Dummy implementation: return a static list
-    return ['https://mcp1.example.com', 'https://mcp2.example.com']
+    const { agent } = getCurrentAgent<Chat>()
+    if (!agent) return 'No agent found'
+    return agent.mcp.mcpConnections
   }
 })
 
@@ -157,10 +158,24 @@ export const executions = {
   },
   addMCPServerUrl: async ({ url }: { url: string }) => {
     console.log(`Adding MCP server url: ${url}`)
-    return `Added MCP url: ${url}`
+    const { agent } = getCurrentAgent<Chat>()
+    try {
+      const { id } = await agent!.addMcpServer(url, url, 'mcp-demo-host')
+      return `Added MCP url: ${url} with id: ${id}`
+    } catch (error) {
+      console.error('Error adding MCP server url', error)
+      return `Error adding MCP url: ${error}`
+    }
   },
-  removeMCPServerUrl: async ({ url }: { url: string }) => {
-    console.log(`Removing MCP server url: ${url}`)
-    return `Removed MCP url: ${url}`
+  removeMCPServerUrl: async ({ id }: { id: string }) => {
+    console.log(`Removing MCP server with id: ${id}`)
+    const { agent } = getCurrentAgent<Chat>()
+    try {
+      agent!.removeMcpServer(id)
+      return `Removed MCP with id: ${id}`
+    } catch (error) {
+      console.error('Error removing MCP server with id', error)
+      return `Error removing MCP with id: ${error}`
+    }
   }
 }


### PR DESCRIPTION
This adds built-in tool support to list, add, and remove MCP servers. The tools to add and remove require user approval.  

<img width="786" alt="Screenshot 2025-05-13 at 19 30 40" src="https://github.com/user-attachments/assets/413c1991-416f-4cb6-9baf-418c7d20a127" />

![Screenshot 2025-05-19 at 19 16 40](https://github.com/user-attachments/assets/a4e9767b-0b80-4a84-a472-ec7a714e56b3)

> [!NOTE]
> MCP server IDs are autogenerated. The name when you list MCP servers is the same as the ID. We might modify the tool add/remove api to support user-provided names instead of exposing the IDs.

<img width="786" alt="Screenshot 2025-05-13 at 19 49 41" src="https://github.com/user-attachments/assets/fdb0bda9-bad9-4669-9770-e4cd0b89756d" />



### Refs

- https://blog.cloudflare.com/building-ai-agents-with-mcp-authn-authz-and-durable-objects/#ai-agents-can-now-act-as-remote-mcp-clients-with-transport-and-auth-included
- https://github.com/cloudflare/ai/blob/main/demos/mcp-client/src/server.ts
- https://github.com/cloudflare/agents/blob/2801d35ff03fb41c75904fe96690766457e6b307/packages/agents/src/index.ts#L926-L935



