### PR TITLE
Close connection when removing MCP

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -171,6 +171,7 @@ export const executions = {
     console.log(`Removing MCP server with id: ${id}`)
     const { agent } = getCurrentAgent<Chat>()
     try {
+      agent!.mcp.closeConnection(id)
       agent!.removeMcpServer(id)
       return `Removed MCP with id: ${id}`
     } catch (error) {


### PR DESCRIPTION
This is an experiment to see if closing the connection when removing an MCP server also make the DO go to sleep more reliably. I [noticed](https://github.com/jldec/mcp-demo/issues/5) that DOs with MCP tool connections stay alive for hours (costing GB-s wall-time). The theory for why this is happening is that long-polling SSE HTTP connections prevent DO shutdown. Hopefull this will stop being a problem when the MCP client and servers default to using  the new "streaming HTTP" transport which defauts to simple POST for non-bidirectional calls (I think).